### PR TITLE
Add Vietnamese translations for questions about decades and years

### DIFF
--- a/translations/vi/decade.md
+++ b/translations/vi/decade.md
@@ -1,0 +1,40 @@
+1. Bạn sẽ làm gì nếu chỉ còn sống 6 tháng nữa?
+2. Bạn sẽ làm gì nếu có một tỷ đô la?
+3. Bạn sẽ khuyên bản thân 10 năm trước như thế nào?
+4. Bạn hy vọng điều gì sẽ giữ nguyên 10 năm nữa?
+5. Bạn hy vọng điều gì sẽ khác 10 năm nữa?
+6. Theo bạn, hạnh phúc hoàn hảo là gì?
+7. Bạn cảm thấy hạnh phúc nhất khi nào và ở đâu?
+8. Tại sao bạn thức dậy vào buổi sáng?
+9. Bạn cho rằng đau khổ tột cùng là gì?
+10. Đặc điểm nổi bật nhất của bạn là gì?
+11. Nỗi sợ lớn nhất của bạn là gì?
+12. Bạn ghét điều gì nhất ở bản thân?
+13. Bạn ghét điều gì nhất ở người khác?
+14. Bạn nói dối vào dịp nào?
+15. Sự xa xỉ lớn nhất của bạn là gì?
+16. Bạn cho rằng đức tính nào được đánh giá quá cao?
+17. Bạn không thích điều gì về ngoại hình của mình?
+18. Nếu bạn có thể thay đổi một điều về bản thân, đó sẽ là gì?
+19. Bạn ước có tài năng gì nhất?
+20. Người khác thường hiểu lầm bạn về điều gì?
+21. Bạn thích đức tính nào nhất ở đàn ông?
+22. Bạn thích đức tính nào nhất ở phụ nữ?
+23. Bạn trân trọng điều gì nhất ở bạn bè?
+24. Thành tựu lớn nhất của bạn là gì?
+25. Nếu bạn có thể tặng mỗi người trên thế giới một món quà, đó sẽ là gì?
+26. Sự lãng phí thời gian lớn nhất của bạn là gì?
+27. Bạn thấy đau đớn nhưng vẫn đáng làm là gì?
+28. Bạn muốn sống ở đâu nhất?
+29. Tài sản quý giá nhất của bạn là gì?
+30. Bạn thân nhất của bạn là ai?
+31. Ai hoặc điều gì là tình yêu lớn nhất của đời bạn?
+32. Người đang sống mà bạn ngưỡng mộ nhất là ai?
+33. Anh hùng hư cấu nào bạn yêu thích nhất?
+34. Nhân vật lịch sử nào bạn đồng cảm nhất?
+35. Hối tiếc lớn nhất của bạn là gì?
+36. Bạn muốn chết như thế nào?
+37. Phương châm sống của bạn là gì?
+38. Lời khen tốt nhất bạn từng nhận là gì?
+39. Điều may mắn nhất xảy đến với bạn là gì?
+40. Điều gì khiến bạn hy vọng?

--- a/translations/vi/year.md
+++ b/translations/vi/year.md
@@ -1,0 +1,40 @@
+1. Bạn đã làm gì trong năm nay mà bạn chưa từng làm trước đó?
+2. Bạn có giữ lời hứa đầu năm của mình không?
+3. Có ai thân cận với bạn sinh con không?
+4. Có ai thân cận với bạn qua đời không?
+5. Bạn đã đi thăm những thành phố/bang/quốc gia nào?
+6. Bạn muốn có gì trong năm tới mà bạn thiếu trong năm nay?
+7. Ngày nào trong năm nay sẽ được khắc sâu vào ký ức của bạn, và tại sao?
+8. Thành tựu lớn nhất của bạn trong năm nay là gì?
+9. Thất bại lớn nhất của bạn là gì?
+10. Bạn đã đối mặt với những khó khăn gì khác?
+11. Bạn có bị ốm hay chấn thương không?
+12. Thứ tốt nhất bạn đã mua là gì?
+13. Hành vi của ai xứng đáng được ăn mừng?
+14. Hành vi của ai khiến bạn phẫn nộ?
+15. Phần lớn tiền của bạn đã đi vào đâu?
+16. Bạn đã thực sự, thực sự, thực sự hào hứng về điều gì?
+17. Bài hát nào sẽ luôn nhắc bạn về năm nay?
+18. So với thời điểm này năm ngoái, bạn có: hạnh phúc hơn hay buồn hơn? Gầy hơn hay mập hơn? Giàu hơn hay nghèo hơn?
+19. Bạn ước gì mình đã làm nhiều hơn?
+20. Bạn ước gì mình đã làm ít hơn?
+21. Bạn dành thời gian lễ như thế nào?
+22. Bạn có yêu đương trong năm nay không?
+23. Bạn có ghét ai bây giờ mà năm ngoái bạn không ghét không?
+24. Chương trình yêu thích của bạn là gì?
+25. Cuốn sách hay nhất bạn đã đọc là gì?
+26. Phát hiện âm nhạc vĩ đại nhất của bạn trong năm nay là gì?
+27. Bộ phim yêu thích của bạn là gì?
+28. Bữa ăn yêu thích của bạn là gì?
+29. Bạn mong muốn điều gì và đã đạt được?
+30. Bạn mong muốn điều gì và không đạt được?
+31. Bạn đã làm gì vào ngày sinh nhật của mình?
+32. Điều gì sẽ làm cho năm của bạn thú vị hơn rất nhiều?
+33. Bạn mô tả phong cách thời trang cá nhân của mình trong năm nay như thế nào?
+34. Điều gì giữ cho bạn tỉnh táo?
+35. Bạn ngưỡng mộ người nổi tiếng/công chúng nào nhất?
+36. Vấn đề chính trị nào khiến bạn quan tâm nhất?
+37. Bạn nhớ ai?
+38. Người mới quen biết tốt nhất của bạn là ai?
+39. Bạn học được bài học quý giá nào trong năm nay?
+40. Câu trích dẫn nào tóm tắt năm của bạn?


### PR DESCRIPTION
This pull request adds Vietnamese translations for questions about decades and years. It includes translations for a total of 80 questions, 40 for each category. These translations will help improve the user experience for Vietnamese-speaking users of the application.
