### PR TITLE
Fine tune annual Vietnamese questions

### DIFF
--- a/translations/vi/year.md
+++ b/translations/vi/year.md
@@ -16,9 +16,9 @@
 16. Bạn đã thực sự, thực sự, thực sự hào hứng về điều gì?
 17. Bài hát nào sẽ luôn nhắc bạn về năm nay?
 18. So với thời điểm này năm ngoái, bạn có: hạnh phúc hơn hay buồn hơn? Gầy hơn hay mập hơn? Giàu hơn hay nghèo hơn?
-19. Bạn ước gì mình đã làm nhiều hơn?
-20. Bạn ước gì mình đã làm ít hơn?
-21. Bạn dành thời gian lễ như thế nào?
+19. Bạn ước mình đã làm gì nhiều hơn?
+20. Bạn ước mình đã làm gì ít hơn?
+21. Bạn đã tận hưởng những ngày nghỉ lễ như thế nào?
 22. Bạn có yêu đương trong năm nay không?
 23. Bạn có ghét ai bây giờ mà năm ngoái bạn không ghét không?
 24. Chương trình yêu thích của bạn là gì?
@@ -34,7 +34,7 @@
 34. Điều gì giữ cho bạn tỉnh táo?
 35. Bạn ngưỡng mộ người nổi tiếng/công chúng nào nhất?
 36. Vấn đề chính trị nào khiến bạn quan tâm nhất?
-37. Bạn nhớ ai?
-38. Người mới quen biết tốt nhất của bạn là ai?
+37. Bạn đã nhớ ai?
+38. Người tốt nhất mà bạn mới quen biết là ai?
 39. Bạn học được bài học quý giá nào trong năm nay?
 40. Câu trích dẫn nào tóm tắt năm của bạn?


### PR DESCRIPTION
Hi, I'm a native Vietnamese speaker. After reading the Vietnamese version, I improved 5 questions in `vi/year.md`. Details in the following:

- 19 & 20: "Bạn ước **gì** mình đã làm nhiều/ít hơn?" sounds more like an affirmative sentence than a question in Vietnamese. So I changed the position of the word **gì** to make it more natural and more suitable for a question.
- 21: I replaced "dành thời gian lễ" (spent holiday time) with "đã tận hưởng những ngày nghỉ lễ" (enjoy holidays). Moreover, in Vietnamese, "dành thời gian lễ" appears to lack meaningful context. It could also be translated to "dành thời gian nghỉ lễ", which is more similar to the original English sentence (spending the holidays).
- 37: I added "đã" to signify past tense in Vietnamese. The original version seemed to convey "Who are you missing?" than the intended "Who did you miss?". 
- 38: just make the wording more natural and less reminiscent of a literal translation from Google.